### PR TITLE
Update src/miui/src/main/miui_ui.c

### DIFF
--- a/src/miui/src/main/miui_ui.c
+++ b/src/miui/src/main/miui_ui.c
@@ -113,7 +113,9 @@ int miui_setbg(char * titlev){
   pthread_mutex_unlock(&title_mutex);
   return 2*elmP + ag_fontheight(1);
 }
+#ifndef BATTERY_CAPACITY_PATH //Define battery capacity for different device
 #define BATTERY_CAPACITY_PATH "/sys/class/power_supply/battery/capacity"
+#endif
 
 static int read_from_file(const char* path, char* buf, size_t size) {
     int fd = open(path, O_RDONLY, 0);


### PR DESCRIPTION
不同的机型电量状态路径不同，因而导致不能正确显示电量状态，
可以考虑在makefile里定义不同的路径以保证电量状态正确显示
